### PR TITLE
lmtm -> byteclubfr; closes #4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Build Status](https://img.shields.io/travis/lmtm/todotxt/master.svg?style=flat)](https://travis-ci.org/lmtm/todotxt)
-[![Dependency Status](https://david-dm.org/lmtm/todotxt.svg?style=flat)](https://david-dm.org/lmtm/todotxt)
-[![devDependency Status](https://david-dm.org/lmtm/todotxt/dev-status.svg?style=flat)](https://david-dm.org/lmtm/todotxt#info=devDependencies)
+[![Build Status](https://img.shields.io/travis/byteclubfr/todotxt/master.svg?style=flat)](https://travis-ci.org/lmtm/todotxt)
+[![Dependency Status](https://david-dm.org/byteclubfr/todotxt.svg?style=flat)](https://david-dm.org/lmtm/todotxt)
+[![devDependency Status](https://david-dm.org/byteclubfr/todotxt/dev-status.svg?style=flat)](https://david-dm.org/lmtm/todotxt#info=devDependencies)
 
 # TodoTxt
 

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/lmtm/todotxt.git"
+    "url": "https://github.com/byteclubfr/todotxt.git"
   },
   "bugs": {
-    "url": "https://github.com/lmtm/todotxt/issues"
+    "url": "https://github.com/byteclubfr/todotxt/issues"
   },
-  "homepage": "https://github.com/lmtm/todotxt"
+  "homepage": "https://github.com/byteclubfr/todotxt"
 }


### PR DESCRIPTION
Use the updated repository. https://github.com/lmtm/todotxt now redirects to https://github.com/byteclubfr/todotxt so I think this is the right repo to use.