### PR TITLE
Use numerical constructor for Date so it is local; closes #2

### DIFF
--- a/index.js
+++ b/index.js
@@ -178,7 +178,15 @@ function regexMatchAll (string, pattern) {
 }
 
 function parseDate (string) {
-  return new Date(string);
+  var match = string.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!match) {
+    throw new Error("Bad date: " + string);
+  }
+  var year = parseInt(match[1], 10);
+  var month = parseInt(match[2], 10);
+  var day = parseInt(match[3], 10);
+  // We use the numerical Date constructor to get the local date
+  return new Date(year, month - 1, day);
 }
 
 function regexTrimLeft (string, pattern, onMatch) {
@@ -326,4 +334,3 @@ function stringifyDate (date) {
 
   return yyyy + "-" + mm + "-" + dd;
 }
-

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Todo.txt format parser/serializer",
   "main": "index.js",
   "scripts": {
-    "test": "mocha --check-leaks --reporter spec",
+    "test": "for tz in America/New_York Europe/Paris; do TZ=$tz npm run test1; done",
+    "test1": "mocha --check-leaks --reporter spec",
     "lint": "eslint ."
   },
   "keywords": [

--- a/test/index.js
+++ b/test/index.js
@@ -139,12 +139,12 @@ describe("TodoTxt", function () {
     });
 
     it("should set completion date", function () {
-      item.completeDate = new Date("2015-03-20");
+      item.completeDate = new Date(2015, 2, 20);
       expect(todotxt.stringify(item)).toEqual("x 2015-03-20 Hello @Context1 @Context2 +SayHello");
     });
 
     it("should set task date too", function () {
-      item.date = new Date("2015-03-18");
+      item.date = new Date(2015, 2, 18);
       expect(todotxt.stringify(item)).toEqual("x 2015-03-20 2015-03-18 Hello @Context1 @Context2 +SayHello");
     });
 


### PR DESCRIPTION
Instead of `new Date(string)` we do `new Date(year, month, day)`, which will give a local value for the ymd. This matters if you're west of GMT, where local midnight is not the same date as GMT midnight.

I also changed the test script so that it runs for two different timezones on either side of GMT, to make sure it works in all cases. 