### PR TITLE
Correctly remove projects from text; closes #13

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,7 +135,7 @@ function todoItem (props) {
   function removeProject (project) {
     if (item.projects.indexOf(project) !== -1) {
       item.projects = _.without(item.projects, project);
-      item.text = removeTag(item.text, "@" + project);
+      item.text = removeTag(item.text, "+" + project);
     }
   }
 
@@ -326,4 +326,3 @@ function stringifyDate (date) {
 
   return yyyy + "-" + mm + "-" + dd;
 }
-

--- a/test/index.js
+++ b/test/index.js
@@ -133,8 +133,14 @@ describe("TodoTxt", function () {
       expect(todotxt.stringify(item)).toEqual("x Hello @Context1 @Context2");
     });
 
-    it("should add project", function () {
+    it("should add projects", function () {
       item.addProject("SayHello");
+      item.addProject("SayGoodbye");
+      expect(todotxt.stringify(item)).toEqual("x Hello @Context1 @Context2 +SayHello +SayGoodbye");
+    });
+
+    it("should remove projects", function () {
+      item.removeProject("SayGoodbye");
       expect(todotxt.stringify(item)).toEqual("x Hello @Context1 @Context2 +SayHello");
     });
 


### PR DESCRIPTION
Fix the prefix so that it correctly removes projects from the text.